### PR TITLE
Update modDesc.xml

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -6,7 +6,7 @@
     <title>
         <de>Oliven Plantage</de>
         <en>Olive Plantage</en>
-        <ru>Оливковый сад</ru>
+        <ru>Оливковый Сад</ru>
     </title>
     
     <description>


### PR DESCRIPTION
Entschuldigung, ich habe vergessen, dass Giants glaubt, dass alle Wörter in einem Mod-Namen mit einem Großbuchstaben beginnen müssen. )))